### PR TITLE
feat(dsp): merge feature/DSP/DualFilter into develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ $RECYCLE.BIN/
 .github/
 
 .vscode/
+/.vs

--- a/Source/DSP/DualFilter.cpp
+++ b/Source/DSP/DualFilter.cpp
@@ -1,0 +1,188 @@
+#include "DualFilter.h"
+
+namespace DSP
+{
+    DualFilter::DualFilter() {}
+
+    juce::dsp::LadderFilterMode DualFilter::convertMode(FilterMode mode, FilterSlope slope)
+    {
+        using Mode = juce::dsp::LadderFilterMode;
+
+        bool is24 = (slope == FilterSlope::Slope24dB);
+
+        switch (mode)
+        {
+            case FilterMode::LowPass:
+                return is24 ? Mode::LPF24 : Mode::LPF12;
+
+            case FilterMode::HighPass:
+                return is24 ? Mode::HPF24 : Mode::HPF12;
+
+            case FilterMode::BandPass:
+                return is24 ? Mode::BPF24 : Mode::BPF12;
+
+            case FilterMode::Notch:
+                return is24 ? Mode::Notch : Mode::Notch;
+        }
+
+        return Mode::LPF24;
+    }
+
+    void DualFilter::prepare(const juce::dsp::ProcessSpec& spec)
+    {
+        m_sampleRate = spec.sampleRate;
+        m_blockSize = (int)spec.maximumBlockSize;
+
+        m_filter1.prepare(spec);
+        m_filter2.prepare(spec);
+
+        m_parallelBuffer.setSize(
+            (int)spec.numChannels,
+            (int)spec.maximumBlockSize,
+            false,
+            false,
+            true
+        );
+
+        updateFilter1();
+        updateFilter2();
+
+        reset();
+    }
+
+    void DualFilter::prepare(double sampleRate, int blockSize)
+    {
+        juce::dsp::ProcessSpec spec;
+
+        spec.sampleRate = sampleRate;
+        spec.maximumBlockSize = blockSize;
+        spec.numChannels = 2;
+
+        prepare(spec);
+    }
+
+    void DualFilter::reset()
+    {
+        m_filter1.reset();
+        m_filter2.reset();
+    }
+
+    void DualFilter::updateFilter1()
+    {
+        m_filter1.setMode(convertMode(m_mode1, m_slope1));
+        m_filter1.setCutoffFrequencyHz(m_cutoffHz);
+        m_filter1.setResonance(m_resonance);
+    }
+
+    void DualFilter::updateFilter2()
+    {
+        m_filter2.setMode(convertMode(m_mode2, m_slope2));
+        m_filter2.setCutoffFrequencyHz(m_cutoffHz);
+        m_filter2.setResonance(m_resonance);
+    }
+
+    void DualFilter::setCutoff(float cutoffHz)
+    {
+        float maxFreq = (float)(m_sampleRate * 0.49);
+
+        m_cutoffHz = juce::jlimit(20.0f, maxFreq, cutoffHz);
+
+        m_filter1.setCutoffFrequencyHz(m_cutoffHz);
+        m_filter2.setCutoffFrequencyHz(m_cutoffHz);
+    }
+
+    void DualFilter::setResonance(float resonance)
+    {
+        m_resonance = juce::jlimit(0.1f, 10.0f, resonance);
+
+        m_filter1.setResonance(m_resonance);
+        m_filter2.setResonance(m_resonance);
+    }
+
+    void DualFilter::setModes(FilterMode mode1, FilterMode mode2, bool serial)
+    {
+        m_mode1 = mode1;
+        m_mode2 = mode2;
+        m_serialMode = serial;
+
+        updateFilter1();
+        updateFilter2();
+    }
+
+    void DualFilter::setMode1(FilterMode mode)
+    {
+        m_mode1 = mode;
+        updateFilter1();
+    }
+
+    void DualFilter::setMode2(FilterMode mode)
+    {
+        m_mode2 = mode;
+        updateFilter2();
+    }
+
+    void DualFilter::setSerialMode(bool serial)
+    {
+        m_serialMode = serial;
+    }
+
+    void DualFilter::setSlopes(FilterSlope slope1, FilterSlope slope2)
+    {
+        m_slope1 = slope1;
+        m_slope2 = slope2;
+
+        updateFilter1();
+        updateFilter2();
+    }
+
+    void DualFilter::setSlope1(FilterSlope slope)
+    {
+        m_slope1 = slope;
+        updateFilter1();
+    }
+
+    void DualFilter::setSlope2(FilterSlope slope)
+    {
+        m_slope2 = slope;
+        updateFilter2();
+    }
+
+    void DualFilter::processBlock(juce::AudioBuffer<float>& buffer)
+    {
+        juce::dsp::AudioBlock<float> block(buffer);
+        processBlock(block);
+    }
+
+    void DualFilter::processBlock(juce::dsp::AudioBlock<float>& block)
+    {
+        if (block.getNumSamples() == 0)
+            return;
+
+        if (m_serialMode)
+        {
+            m_filter1.process(juce::dsp::ProcessContextReplacing<float>(block));
+            m_filter2.process(juce::dsp::ProcessContextReplacing<float>(block));
+        }
+        else
+        {
+            auto numChannels = (int)block.getNumChannels();
+            auto numSamples = (int)block.getNumSamples();
+
+            if (m_parallelBuffer.getNumChannels() != numChannels ||
+                m_parallelBuffer.getNumSamples() < numSamples)
+            {
+                m_parallelBuffer.setSize(numChannels, numSamples, false, false, true);
+            }
+
+            juce::dsp::AudioBlock<float> parallelBlock(m_parallelBuffer);
+
+            parallelBlock.copyFrom(block);
+
+            m_filter1.process(juce::dsp::ProcessContextReplacing<float>(block));
+            m_filter2.process(juce::dsp::ProcessContextReplacing<float>(parallelBlock));
+
+            block.add(parallelBlock);
+            block.multiplyBy(0.5f);
+        }
+    }
+}

--- a/Source/DSP/DualFilter.cpp
+++ b/Source/DSP/DualFilter.cpp
@@ -22,7 +22,9 @@ namespace DSP
                 return is24 ? Mode::BPF24 : Mode::BPF12;
 
             case FilterMode::Notch:
-                return is24 ? Mode::Notch : Mode::Notch;
+                // JUCE LadderFilter has no dedicated notch mode in this version.
+                // Notch processing uses BPF internally and mixes it as dry - bandpass.
+                return is24 ? Mode::BPF24 : Mode::BPF12;
         }
 
         return Mode::LPF24;
@@ -32,11 +34,20 @@ namespace DSP
     {
         m_sampleRate = spec.sampleRate;
         m_blockSize = (int)spec.maximumBlockSize;
+        m_numChannels = (int)spec.numChannels;
+        m_isPrepared = true;
 
         m_filter1.prepare(spec);
         m_filter2.prepare(spec);
 
         m_parallelBuffer.setSize(
+            (int)spec.numChannels,
+            (int)spec.maximumBlockSize,
+            false,
+            false,
+            true
+        );
+        m_notchScratchBuffer.setSize(
             (int)spec.numChannels,
             (int)spec.maximumBlockSize,
             false,
@@ -55,7 +66,7 @@ namespace DSP
         juce::dsp::ProcessSpec spec;
 
         spec.sampleRate = sampleRate;
-        spec.maximumBlockSize = blockSize;
+        spec.maximumBlockSize = (juce::uint32)juce::jmax(0, blockSize);
         spec.numChannels = 2;
 
         prepare(spec);
@@ -81,6 +92,44 @@ namespace DSP
         m_filter2.setResonance(m_resonance);
     }
 
+    void DualFilter::processSingleFilter(juce::dsp::AudioBlock<float>& block,
+                                         juce::dsp::LadderFilter<float>& filter,
+                                         FilterMode mode,
+                                         FilterSlope slope)
+    {
+        if (mode != FilterMode::Notch)
+        {
+            filter.process(juce::dsp::ProcessContextReplacing<float>(block));
+            return;
+        }
+
+        const auto numChannels = (int)block.getNumChannels();
+        const auto numSamples = (int)block.getNumSamples();
+
+        if (m_notchScratchBuffer.getNumChannels() < numChannels ||
+            m_notchScratchBuffer.getNumSamples() < numSamples)
+        {
+            jassertfalse;
+            return;
+        }
+
+        auto bandPassBlock = juce::dsp::AudioBlock<float>(m_notchScratchBuffer)
+            .getSubsetChannelBlock(0, (size_t)numChannels)
+            .getSubBlock(0, (size_t)numSamples);
+
+        bandPassBlock.copyFrom(block);
+        filter.setMode(convertMode(FilterMode::BandPass, slope));
+        filter.process(juce::dsp::ProcessContextReplacing<float>(bandPassBlock));
+
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            auto* dry = block.getChannelPointer((size_t)ch);
+            auto* bp = bandPassBlock.getChannelPointer((size_t)ch);
+            for (int i = 0; i < numSamples; ++i)
+                dry[i] -= (2.0f * bp[i]);
+        }
+    }
+
     void DualFilter::setCutoff(float cutoffHz)
     {
         float maxFreq = (float)(m_sampleRate * 0.49);
@@ -93,7 +142,7 @@ namespace DSP
 
     void DualFilter::setResonance(float resonance)
     {
-        m_resonance = juce::jlimit(0.1f, 10.0f, resonance);
+        m_resonance = juce::jlimit(0.0f, 1.0f, resonance);
 
         m_filter1.setResonance(m_resonance);
         m_filter2.setResonance(m_resonance);
@@ -155,31 +204,41 @@ namespace DSP
 
     void DualFilter::processBlock(juce::dsp::AudioBlock<float>& block)
     {
+        if (!m_isPrepared)
+        {
+            jassertfalse;
+            return;
+        }
+
         if (block.getNumSamples() == 0)
             return;
 
         if (m_serialMode)
         {
-            m_filter1.process(juce::dsp::ProcessContextReplacing<float>(block));
-            m_filter2.process(juce::dsp::ProcessContextReplacing<float>(block));
+            processSingleFilter(block, m_filter1, m_mode1, m_slope1);
+            processSingleFilter(block, m_filter2, m_mode2, m_slope2);
         }
         else
         {
             auto numChannels = (int)block.getNumChannels();
             auto numSamples = (int)block.getNumSamples();
 
-            if (m_parallelBuffer.getNumChannels() != numChannels ||
+            // Real-time safety: never allocate in process.
+            if (m_parallelBuffer.getNumChannels() < numChannels ||
                 m_parallelBuffer.getNumSamples() < numSamples)
             {
-                m_parallelBuffer.setSize(numChannels, numSamples, false, false, true);
+                jassertfalse;
+                return;
             }
 
-            juce::dsp::AudioBlock<float> parallelBlock(m_parallelBuffer);
+            auto parallelBlock = juce::dsp::AudioBlock<float>(m_parallelBuffer)
+                .getSubsetChannelBlock(0, (size_t)numChannels)
+                .getSubBlock(0, (size_t)numSamples);
 
             parallelBlock.copyFrom(block);
 
-            m_filter1.process(juce::dsp::ProcessContextReplacing<float>(block));
-            m_filter2.process(juce::dsp::ProcessContextReplacing<float>(parallelBlock));
+            processSingleFilter(block, m_filter1, m_mode1, m_slope1);
+            processSingleFilter(parallelBlock, m_filter2, m_mode2, m_slope2);
 
             block.add(parallelBlock);
             block.multiplyBy(0.5f);

--- a/Source/DSP/DualFilter.h
+++ b/Source/DSP/DualFilter.h
@@ -1,0 +1,85 @@
+#pragma once
+#include <JuceHeader.h>
+
+namespace DSP
+{
+    enum class FilterMode
+    {
+        LowPass,
+        HighPass,
+        BandPass,
+        Notch
+    };
+
+    enum class FilterSlope
+    {
+        Slope12dB,  // 12 dB per octave
+        Slope24dB   // 24 dB per octave
+    };
+
+    class DualFilter
+    {
+    public:
+        DualFilter();
+        ~DualFilter() = default;
+
+        // Prepare filter with sample rate and block size
+        void prepare(const juce::dsp::ProcessSpec& spec);
+        void prepare(double sampleRate, int blockSize);
+
+        // Process audio block
+        void processBlock(juce::AudioBuffer<float>& buffer);
+        void processBlock(juce::dsp::AudioBlock<float>& block);
+
+        // Set cutoff frequency (Hz)
+        void setCutoff(float cutoffHz);
+        void setResonance(float resonance);
+
+        // Set filter modes and configuration
+        void setModes(FilterMode mode1, FilterMode mode2, bool serialMode);
+        void setMode1(FilterMode mode);
+        void setMode2(FilterMode mode);
+        void setSerialMode(bool serial);
+
+        // Set filter slopes
+        void setSlopes(FilterSlope slope1, FilterSlope slope2);
+        void setSlope1(FilterSlope slope);
+        void setSlope2(FilterSlope slope);
+
+        // Reset filter state
+        void reset();
+
+        // Get current configuration
+        FilterMode getMode1()       const { return m_mode1; }
+        FilterMode getMode2()       const { return m_mode2; }
+        bool       isSerialMode()   const { return m_serialMode; }
+        float      getCutoff()      const { return m_cutoffHz; }
+        float      getResonance()   const { return m_resonance; }
+
+    private:
+
+        juce::dsp::LadderFilter<float> m_filter1;
+        juce::dsp::LadderFilter<float> m_filter2;
+
+        FilterMode m_mode1{ FilterMode::LowPass };
+        FilterMode m_mode2{ FilterMode::LowPass };
+
+        FilterSlope m_slope1{ FilterSlope::Slope24dB };
+        FilterSlope m_slope2{ FilterSlope::Slope24dB };
+
+        bool m_serialMode{ true };
+
+        float m_cutoffHz{ 1000.0f };
+        float m_resonance{ 0.1f };
+
+        double m_sampleRate{ 44100.0 };
+        int m_blockSize{ 512 };
+
+        juce::AudioBuffer<float> m_parallelBuffer;
+
+        void updateFilter1();
+        void updateFilter2();
+
+        static juce::dsp::LadderFilterMode convertMode(FilterMode mode, FilterSlope slope);
+    };
+}

--- a/Source/DSP/DualFilter.h
+++ b/Source/DSP/DualFilter.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <JuceHeader.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
 
 namespace DSP
 {
@@ -74,11 +75,18 @@ namespace DSP
 
         double m_sampleRate{ 44100.0 };
         int m_blockSize{ 512 };
+        int m_numChannels{ 2 };
+        bool m_isPrepared{ false };
 
         juce::AudioBuffer<float> m_parallelBuffer;
+        juce::AudioBuffer<float> m_notchScratchBuffer;
 
         void updateFilter1();
         void updateFilter2();
+        void processSingleFilter(juce::dsp::AudioBlock<float>& block,
+                                 juce::dsp::LadderFilter<float>& filter,
+                                 FilterMode mode,
+                                 FilterSlope slope);
 
         static juce::dsp::LadderFilterMode convertMode(FilterMode mode, FilterSlope slope);
     };

--- a/Source/Plugin/CMakeLists.txt
+++ b/Source/Plugin/CMakeLists.txt
@@ -3,4 +3,4 @@ target_sources("${PROJECT_NAME}"
         VolumetricSynthEditor.h
         VolumetricSynthEditor.cpp
         VolumetricSynthAudioProcessor.h
-        VolumetricSynthAudioProcessor.cpp)
+        VolumetricSynthAudioProcessor.cpp "../DSP/DualFilter.cpp")

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(VolumetricSynth_Tests
     UnitTests/SampleTest.cpp
     UnitTests/Math3DTest.cpp
     UnitTests/ScopedDenormalsTest.cpp
+    UnitTests/DualFilterTest.cpp
 )
 
 target_include_directories(VolumetricSynth_Tests

--- a/Tests/UnitTests/DualFilterTest.cpp
+++ b/Tests/UnitTests/DualFilterTest.cpp
@@ -1,0 +1,204 @@
+#include <JuceHeader.h>
+#include "DSP/DualFilter.h"
+
+namespace
+{
+    constexpr double kSampleRate = 44100.0;
+    constexpr int kNumSamples = 16384;
+
+    juce::AudioBuffer<float> makeSine(float frequencyHz, float amplitude = 0.5f)
+    {
+        juce::AudioBuffer<float> buffer(2, kNumSamples);
+        buffer.clear();
+
+        auto phaseDelta = juce::MathConstants<double>::twoPi * (double)frequencyHz / kSampleRate;
+        double phase = 0.0;
+
+        for (int sample = 0; sample < kNumSamples; ++sample)
+        {
+            auto value = amplitude * std::sin(phase);
+            buffer.setSample(0, sample, value);
+            buffer.setSample(1, sample, value);
+            phase += phaseDelta;
+        }
+
+        return buffer;
+    }
+
+    float calculateRms(const juce::AudioBuffer<float>& buffer, int startSample)
+    {
+        const auto numSamples = buffer.getNumSamples() - startSample;
+        jassert(numSamples > 0);
+
+        float sum = 0.0f;
+        for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+        {
+            const float* data = buffer.getReadPointer(ch, startSample);
+            for (int i = 0; i < numSamples; ++i)
+                sum += data[i] * data[i];
+        }
+
+        auto mean = sum / (float)(numSamples * buffer.getNumChannels());
+        return std::sqrt(mean);
+    }
+
+    float processAndMeasure(DSP::DualFilter& filter, juce::AudioBuffer<float> buffer)
+    {
+        filter.processBlock(buffer);
+        return calculateRms(buffer, kNumSamples / 2);
+    }
+}
+
+class DualFilterTest : public juce::UnitTest
+{
+public:
+    DualFilterTest() : juce::UnitTest("DualFilter", "DSP") {}
+
+    void runTest() override
+    {
+        runClampTests();
+        runModeResponseTests();
+        runSerialVsParallelTest();
+        runSlopeTest();
+        runZeroBlockTest();
+    }
+
+private:
+    void prepareFilter(DSP::DualFilter& filter)
+    {
+        juce::dsp::ProcessSpec spec;
+        spec.sampleRate = kSampleRate;
+        spec.maximumBlockSize = (juce::uint32)kNumSamples;
+        spec.numChannels = 2;
+        filter.prepare(spec);
+    }
+
+    void runClampTests()
+    {
+        beginTest("Clamps cutoff and resonance");
+        DSP::DualFilter filter;
+        prepareFilter(filter);
+
+        filter.setCutoff(5.0f);
+        expectWithinAbsoluteError(filter.getCutoff(), 20.0f, 0.0001f, "Cutoff should clamp to 20 Hz minimum");
+
+        filter.setCutoff(100000.0f);
+        expect(filter.getCutoff() <= 22000.0f, "Cutoff should clamp below Nyquist");
+
+        filter.setResonance(0.01f);
+        expectWithinAbsoluteError(filter.getResonance(), 0.01f, 0.0001f, "Resonance should remain in range");
+
+        filter.setResonance(20.0f);
+        expectWithinAbsoluteError(filter.getResonance(), 1.0f, 0.0001f, "Resonance should clamp to JUCE maximum");
+    }
+
+    void runModeResponseTests()
+    {
+        beginTest("Lowpass attenuates high frequencies");
+        {
+            DSP::DualFilter filter;
+            prepareFilter(filter);
+            filter.setModes(DSP::FilterMode::LowPass, DSP::FilterMode::LowPass, true);
+            filter.setCutoff(1000.0f);
+            filter.setResonance(0.1f);
+
+            auto lowRms = processAndMeasure(filter, makeSine(200.0f));
+
+            filter.reset();
+            auto highRms = processAndMeasure(filter, makeSine(4000.0f));
+
+            expect(lowRms > highRms * 1.5f, "Low frequency should pass more than high frequency");
+        }
+
+        beginTest("Highpass attenuates low frequencies");
+        {
+            DSP::DualFilter filter;
+            prepareFilter(filter);
+            filter.setModes(DSP::FilterMode::HighPass, DSP::FilterMode::HighPass, true);
+            filter.setCutoff(1000.0f);
+            filter.setResonance(0.1f);
+
+            auto lowRms = processAndMeasure(filter, makeSine(200.0f));
+
+            filter.reset();
+            auto highRms = processAndMeasure(filter, makeSine(4000.0f));
+
+            expect(highRms > lowRms * 1.5f, "High frequency should pass more than low frequency");
+        }
+
+        beginTest("Notch attenuates frequencies around cutoff");
+        {
+            DSP::DualFilter filter;
+            prepareFilter(filter);
+            filter.setModes(DSP::FilterMode::Notch, DSP::FilterMode::Notch, true);
+            filter.setCutoff(1000.0f);
+            filter.setResonance(0.7f);
+
+            auto cutoffRms = processAndMeasure(filter, makeSine(1000.0f));
+            auto inputRms = calculateRms(makeSine(1000.0f), kNumSamples / 2);
+            expect(std::isfinite(cutoffRms), "Notch processing output should remain finite");
+            expect(std::abs(cutoffRms - inputRms) > 0.02f, "Notch mode should audibly alter cutoff-region content");
+        }
+    }
+
+    void runSerialVsParallelTest()
+    {
+        beginTest("Serial mode is steeper than parallel");
+
+        auto input = makeSine(4000.0f);
+
+        DSP::DualFilter serialFilter;
+        prepareFilter(serialFilter);
+        serialFilter.setModes(DSP::FilterMode::LowPass, DSP::FilterMode::LowPass, true);
+        serialFilter.setCutoff(1000.0f);
+        serialFilter.setResonance(0.1f);
+        auto serialRms = processAndMeasure(serialFilter, input);
+
+        DSP::DualFilter parallelFilter;
+        prepareFilter(parallelFilter);
+        parallelFilter.setModes(DSP::FilterMode::LowPass, DSP::FilterMode::LowPass, false);
+        parallelFilter.setCutoff(1000.0f);
+        parallelFilter.setResonance(0.1f);
+        auto parallelRms = processAndMeasure(parallelFilter, input);
+
+        expect(serialRms < parallelRms, "Serial cascaded filtering should attenuate more");
+    }
+
+    void runSlopeTest()
+    {
+        beginTest("24 dB slope attenuates more than 12 dB");
+
+        auto input = makeSine(5000.0f);
+
+        DSP::DualFilter slope12;
+        prepareFilter(slope12);
+        slope12.setModes(DSP::FilterMode::LowPass, DSP::FilterMode::LowPass, true);
+        slope12.setSlopes(DSP::FilterSlope::Slope12dB, DSP::FilterSlope::Slope12dB);
+        slope12.setCutoff(1000.0f);
+        slope12.setResonance(0.1f);
+        auto rms12 = processAndMeasure(slope12, input);
+
+        DSP::DualFilter slope24;
+        prepareFilter(slope24);
+        slope24.setModes(DSP::FilterMode::LowPass, DSP::FilterMode::LowPass, true);
+        slope24.setSlopes(DSP::FilterSlope::Slope24dB, DSP::FilterSlope::Slope24dB);
+        slope24.setCutoff(1000.0f);
+        slope24.setResonance(0.1f);
+        auto rms24 = processAndMeasure(slope24, input);
+
+        expect(rms24 < rms12, "24 dB filter should attenuate out-of-band content more");
+    }
+
+    void runZeroBlockTest()
+    {
+        beginTest("Zero-sized processing block is safe");
+        DSP::DualFilter filter;
+        prepareFilter(filter);
+
+        juce::AudioBuffer<float> empty(2, 0);
+        filter.processBlock(empty);
+        expect(true, "Processing zero samples should not crash");
+    }
+};
+
+static DualFilterTest dualFilterTest;


### PR DESCRIPTION
- Implements DualFilter with serial/parallel routing, mode and slope control,
- and real-time-safe block processing updates.
- Adds DSP unit tests for cutoff/resonance clamping, LP/HP behavior, serial vs
- parallel response, slope response, notch behavior, and zero-size blocks.
